### PR TITLE
修复jd_identical.py禁用重复任务失败-无法获取 token!!!

### DIFF
--- a/jd_identical.py
+++ b/jd_identical.py
@@ -155,7 +155,7 @@ def disable_duplicate_tasks(ids: list) -> None:
 
 def get_token() -> str or None:
     try:
-        with open("/ql/config/auth.json", "r", encoding="utf-8") as f:
+        with open("/ql/data/config/auth.json", "r", encoding="utf-8") as f:
             data = json.load(f)
     except Exception:
         logger.info(f"❌无法获取 token!!!\n{traceback.format_exc()}")


### PR DESCRIPTION
auth.json位于/ql/data/config而非/ql/config