### PR TITLE
Update jd_get_share_code.js 修复错误未捕获导致获取互助码任务中断

### DIFF
--- a/jd_get_share_code.js
+++ b/jd_get_share_code.js
@@ -589,16 +589,21 @@ function getJdCash() {
 }
 async function getShareCode() {
   console.log(`======账号${$.index}开始======`)
-  await getJDFruit()
-  await getJdPet()
-  await getPlantBean()
-  await getJdFactory()
-  await getJxFactory()
-  await getJdZZ()
-  await getJoy()
-  await getSgmh()
-  //await getCFD()
-  await getJdCash()
+  try {
+    await getJDFruit()
+    await getJdPet()
+    await getPlantBean()
+    await getJdFactory()
+    await getJxFactory()
+    await getJdZZ()
+    await getJoy()
+    await getSgmh()
+    //await getCFD()
+    await getJdCash()
+  } catch (e) {
+    console.log(e)
+  }
+    
   console.log(`======账号${$.index}结束======\n`)
 }
 


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'jwordShareInfo')
    at jdPlantBean (/ql/scripts/shufflewzc_faker2_main/jd_get_share_code.js:353:52)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async getPlantBean (/ql/scripts/shufflewzc_faker2_main/jd_get_share_code.js:364:3)
    at async getShareCode (/ql/scripts/shufflewzc_faker2_main/jd_get_share_code.js:595:5)
    at async /ql/scripts/shufflewzc_faker2_main/jd_get_share_code.js:54:7